### PR TITLE
import pyquora submodule in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Get the user's latest upvoted answers.
 # Installation
 If you want to run the API locally:
 
+    $ git submodule update --init --recursive # get pyquora
     $ pip install -r requirements.txt
     $ python server.py
 


### PR DESCRIPTION
I suppose this is obvious for seasoned users of git, but it might be nice to include it anyway.
