### PR TITLE
Extra infos add to the Readme about get_user_stats and contributing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ $ python server.py
 
 # Contributing
 Feel free to submit a pull request or an issue!
+
 quora-api use the pyquora package (https://github.com/csu/pyquora )


### PR DESCRIPTION
Added information about what get_user_stats output ("blogs" and "topics" are set to null) + a direct link to pyquora. 
